### PR TITLE
[4.0.0] Improve test stability by handling timing and visibility issues

### DIFF
--- a/cypress/integration/publisher/004-endpoints/09-usage-warning-certificates.spec.js
+++ b/cypress/integration/publisher/004-endpoints/09-usage-warning-certificates.spec.js
@@ -55,7 +55,7 @@ describe("Endpoint certificate usage testing", () => {
 
             // Select endpoint
             cy.get('#endpoint-certificate').click();
-            cy.get(`[data-value="${selectedEndpoint}"]`).click({ multiple: true });
+            cy.get(`[data-value="${selectedEndpoint}"]`, { timeout: 10000 }).should('exist').click({ force: true, multiple: true }); 
 
             // Set alias
             cy.get('#certificateAlias').click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -729,12 +729,13 @@ Cypress.Commands.add('disableSelfSignUpInCarbonPortal', (username, password, ten
     })
 
     cy.carbonLogin(username, password, tenant);
-    cy.get('[style="background-image: url(../idpmgt/images/resident-idp.png);"]').click();
+    cy.get('[style="background-image: url(../idpmgt/images/resident-idp.png);"]').should('be.visible').click();
     cy.contains('User Onboarding').click();
     cy.contains('Self Registration').click();
     cy.get('[value="SelfRegistration.Enable"]').uncheck({force: true});
     cy.get('#idp-mgt-edit-local-form').submit();
-    cy.get('[class="ui-dialog-buttonpane"]').click();
+    cy.get('.ui-dialog-buttonpane', { timeout: 10000 }).should('be.visible');
+    cy.get('.ui-dialog-buttonpane button').click({ force: true });
     cy.carbonLogout();
 })
 
@@ -745,12 +746,13 @@ Cypress.Commands.add('enableSelfSignUpInCarbonPortal', (username, password, tena
     })
 
     cy.carbonLogin(username, password, tenant);
-    cy.get('[style="background-image: url(../idpmgt/images/resident-idp.png);"]').click();
+    cy.get('[style="background-image: url(../idpmgt/images/resident-idp.png);"]').should('be.visible').click();
     cy.contains('User Onboarding').click();
     cy.contains('Self Registration').click();
     cy.get('[value="SelfRegistration.Enable"]').check({force: true});
     cy.get('#idp-mgt-edit-local-form').submit();
-    cy.get('[class="ui-dialog-buttonpane"]').click();
+    cy.get('.ui-dialog-buttonpane', { timeout: 10000 }).should('be.visible');
+    cy.get('.ui-dialog-buttonpane button').click({ force: true });
     cy.carbonLogout();
 })
 


### PR DESCRIPTION
## Purpose
Resolves the following failing test cases:
- devportal/000-general/03-self-signup.spec.js
- publisher/004-endpoints/09-usage-warning-certificates.spec.js

## Approach
This PR addresses test flakiness and intermittent failures in Cypress end-to-end tests caused by asynchronous rendering and UI visibility issues. The following improvements were made:

### Fix 1: Ensure Dropdown Option is Loaded Before Click

- Added a timeout and `should('exist')` to wait for the element.
- Added `force: true` to ensure interaction even if the element appears off-screen or is overlapped

### Fix 2: Ensure Visibility and Interaction with Carbon Portal UI Elements

- Wait for the Resident IDP icon to be visible before clicking.
- Use `should('be.visible')` and increase timeout for the confirmation dialog.
- Target the actual button inside `.ui-dialog-buttonpane` and use `force: true` to ensure click action.

### Related PRs:

- https://github.com/wso2/apim-test-integration/pull/305